### PR TITLE
Added input visualiser

### DIFF
--- a/physics_platformer/addons/replay_qol/Recorder_Controller.tscn
+++ b/physics_platformer/addons/replay_qol/Recorder_Controller.tscn
@@ -8,6 +8,7 @@ script = ExtResource("1_6qf2e")
 [node name="PopupPanel" type="PopupPanel" parent="."]
 position = Vector2i(50, 400)
 size = Vector2i(700, 50)
+visible = true
 
 [node name="Control" type="Control" parent="PopupPanel"]
 layout_mode = 3
@@ -42,6 +43,19 @@ offset_right = 690.0
 offset_bottom = 23.0
 horizontal_alignment = 2
 vertical_alignment = 1
+
+[node name="PopupPanel2" type="PopupPanel" parent="."]
+position = Vector2i(14, 15)
+size = Vector2i(130, 320)
+visible = true
+
+[node name="Control2" type="Control" parent="PopupPanel2"]
+layout_mode = 3
+anchors_preset = 0
+offset_left = 4.0
+offset_top = 4.0
+offset_right = 126.0
+offset_bottom = 316.0
 
 [connection signal="pressed" from="PopupPanel/Control/PlayStopButton" to="." method="_on_play_stop_button_pressed"]
 [connection signal="drag_started" from="PopupPanel/Control/TimeLineSlider" to="." method="_on_time_line_slider_drag_started"]

--- a/physics_platformer/addons/replay_qol/input_label.tscn
+++ b/physics_platformer/addons/replay_qol/input_label.tscn
@@ -1,0 +1,9 @@
+[gd_scene format=3 uid="uid://cmchvo5k0y53f"]
+
+[node name="Label" type="Label"]
+offset_left = 13.0
+offset_top = 1.0
+offset_right = 108.0
+offset_bottom = 50.0
+text = "test"
+horizontal_alignment = 1

--- a/physics_platformer/addons/replay_qol/recorder_controller.gd
+++ b/physics_platformer/addons/replay_qol/recorder_controller.gd
@@ -10,6 +10,8 @@ func _ready() -> void:
 		force_pause_replay()
 		
 	set_controls_popup_panel($PopupPanel)
+	set_input_popup_panel($PopupPanel2)
+	set_label_parent($PopupPanel2/Control2)
 	set_time_line_slider($PopupPanel/Control/TimeLineSlider)
 	set_frame_counter_label($PopupPanel/Control/ReplayFrameCounter)
 

--- a/src/recorder_controller.cpp
+++ b/src/recorder_controller.cpp
@@ -76,53 +76,49 @@ void Recorder_Controller::update()
 			recorder->set_controlled_replay(true);
 			recorder->force_pause_replay();
 		}
-	}
 
-	godot::Array actions = input_map_singleton->get_actions();
+		godot::Array actions = input_map_singleton->get_actions();
 
-	for (int i = 0; i < actions.size(); i++) 
-	{
-		godot::StringName action_name = actions[i];
-		if (action_name == godot::StringName("start_recording") || action_name == godot::StringName("stop_recording") || action_name == godot::StringName("start_replay") || action_name == godot::StringName("stop_replay")) {
-			continue;
-		}
-
-		if (input_singleton->is_action_just_pressed(action_name)) 
-		{
-			if (label_scene.is_null()) {
-				godot::print_line("Failed to load MyLabel.tscn!");
-				return;
+		for (int i = 0; i < actions.size(); i++) {
+			godot::StringName action_name = actions[i];
+			if (action_name == godot::StringName("start_recording") || action_name == godot::StringName("stop_recording") || action_name == godot::StringName("start_replay") || action_name == godot::StringName("stop_replay")) {
+				continue;
 			}
 
-			for (int i = 0; i < input_lable_parent->get_child_count(); i++) 
-			{
-				godot::Node* child = input_lable_parent->get_child(i);
-				godot::Label *label = godot::Object::cast_to<godot::Label>(child);
-
-				godot::Vector2 pos = label->get_position();
-				pos.y += 30;
-				label->set_position(pos);
-
-				int times_moved = label->get_meta("times_moved", 0);
-				times_moved++;
-				label->set_meta("times_moved", times_moved);
-
-				if (times_moved >= 10) 
-				{
-					label->queue_free();
+			if (input_singleton->is_action_just_pressed(action_name)) {
+				if (label_scene.is_null()) {
+					godot::print_line("Failed to load MyLabel.tscn!");
+					return;
 				}
-			
+
+				for (int i = 0; i < input_lable_parent->get_child_count(); i++) {
+					godot::Node *child = input_lable_parent->get_child(i);
+					godot::Label *label = godot::Object::cast_to<godot::Label>(child);
+
+					godot::Vector2 pos = label->get_position();
+					pos.y += 30;
+					label->set_position(pos);
+
+					int times_moved = label->get_meta("times_moved", 0);
+					times_moved++;
+					label->set_meta("times_moved", times_moved);
+
+					if (times_moved >= 10) {
+						label->queue_free();
+					}
+				}
+				Node *label_instance = label_scene->instantiate();
+
+				godot::Label *label = godot::Object::cast_to<godot::Label>(label_instance);
+				label->set_text(action_name);
+				label->set_meta("times_moved", 0);
+
+				input_lable_parent->add_child(label_instance);
 			}
-			Node *label_instance = label_scene->instantiate();
-
-			godot::Label* label = godot::Object::cast_to<godot::Label>(label_instance);
-			label->set_text(action_name);
-			label->set_meta("times_moved", 0);
-			
-			input_lable_parent->add_child(label_instance);
-
 		}
 	}
+
+	
 }
 void Recorder_Controller::exit_replay()
 {

--- a/src/recorder_controller.hpp
+++ b/src/recorder_controller.hpp
@@ -1,8 +1,11 @@
 #pragma once
+#include "godot_cpp/classes/control.hpp"
 #include "godot_cpp/classes/h_slider.hpp"
 #include "godot_cpp/classes/label.hpp"
+#include "godot_cpp/classes/packed_scene.hpp"
 #include "godot_cpp/classes/popup_panel.hpp"
 #include "recorder.hpp"
+#include "godot_cpp/classes/resource_loader.hpp"
 
 class Recorder_Controller : public godot::Node {
 	// Make class usable in godot with gdscript
@@ -15,10 +18,17 @@ protected:
 private:
 	Recorder *recorder;
     godot::PopupPanel *controls_popup_panel;
+	godot::PopupPanel *input_popup_panel;
+	godot::Control *input_lable_parent;
     godot::HSlider *time_line_slider;
 	godot::Label *frame_counter_ui;
 	godot::String label_string_static_part;
     bool is_replaying = false;
+
+	godot::Input *input_singleton = godot::Input::get_singleton(); //Input interface
+	godot::InputMap *input_map_singleton = godot::InputMap::get_singleton(); //List of possible inputs
+
+	godot::Ref<godot::PackedScene> label_scene = godot::ResourceLoader::get_singleton()->load("res://addons/replay_qol/input_label.tscn");
 
 public:
 
@@ -63,4 +73,8 @@ public:
 	}
 
     void set_controls_popup(godot::PopupPanel*panel);
+
+	void set_input_popup(godot::PopupPanel*panel);
+
+	void set_input_lable_parent(godot::Control*control);
 };


### PR DESCRIPTION
Feature:
Add input queue and visualizer when in replay mode

Requirements:
- [x] Create in-game ui container
- [x] Create input queue
- [x] Generate label per input
- [x] Limit and pool the max inputs

Acceptance criteria:
- [x] When an input get triggered display the action name, when another one triggers, move the previous one one step down.
