### PR TITLE
3D position json saving

### DIFF
--- a/physics_platformer/addons/replay_qol/instant_replay_recorder.gd
+++ b/physics_platformer/addons/replay_qol/instant_replay_recorder.gd
@@ -8,15 +8,18 @@ var is_replaying: bool = false
 
 @export var nodes_array: Array[Node] = []
 @export var json_path: JSON
+@export var json_3d_path: JSON
 @export var input_json_path: JSON
 @export var custom_json_path: JSON
 
 func _ready() -> void:
 	set_tracked_nodes(nodes_array)
-	
+	 
 	set_json_path(json_path)
+	set_3d_json_path(json_3d_path)
 	set_input_json_path(input_json_path)
 	set_custom_json_path(custom_json_path)
+	
 	load_json_file()
 	start_recording()
 	pass

--- a/src/recorder.cpp
+++ b/src/recorder.cpp
@@ -129,6 +129,7 @@ void Recorder::stop_recording()
 	is_recording = false;
 	godot::print_line("Stopping recording");
 	save_2dpos_to_json();
+	save_3dpos_to_json();
 	save_input_to_json();
 	save_custom_to_json();
 }
@@ -395,7 +396,7 @@ void Recorder::save_3dpos_to_json()
 	godot::String filename;
 
 	while (true) {
-		filename = "res://addons/replay_qol/json/test_" + godot::String::num(recording_index) + ".json";
+		filename = "res://addons/replay_qol/json/test3d_" + godot::String::num(recording_index) + ".json";
 
 		if (!godot::FileAccess::file_exists(filename)) {
 			break; // found available filename

--- a/src/recorder.cpp
+++ b/src/recorder.cpp
@@ -352,6 +352,65 @@ void Recorder::save_2dpos_to_json()
 	}
 }
 
+void Recorder::save_3dpos_to_json()
+{
+	if(!json_enabled)
+	{
+		return;
+	}
+
+	godot::Dictionary node_entries;
+
+	for (int currentFrame = 0; currentFrame < recording_frame; currentFrame++) {
+		auto range3d = temporary_data_map_3d_pos.equal_range(currentFrame);
+
+		for (auto iterator = range3d.first; iterator != range3d.second; iterator++) {
+			auto node = std::get<0>(iterator->second);
+			auto position = std::get<1>(iterator->second);
+			
+			godot::Dictionary entry;
+			entry["frame"] = currentFrame;
+			entry["pos"] = position;
+
+			godot::String node_name = node->get_path();
+
+			// If node key doesn’t exist, create an array
+			if (!node_entries.has(node_name)) {
+				node_entries[node_name] = godot::Array();
+			}
+
+			// Push entry into the node’s array
+			node_entries[node_name].call("push_back", entry);
+		}
+	}
+
+	godot::Dictionary root;
+	root["recorder_nodes"] = tracked_nodes.size();
+	root["frame_count"] = recording_frame; // total number of frames
+	root["entries"] = node_entries;
+
+	auto json_string = godot::JSON::stringify(root);
+
+	int recording_index = 0;
+	godot::String filename;
+
+	while (true) {
+		filename = "res://addons/replay_qol/json/test_" + godot::String::num(recording_index) + ".json";
+
+		if (!godot::FileAccess::file_exists(filename)) {
+			break; // found available filename
+		}
+		recording_index++;
+	}
+
+	auto file = godot::FileAccess::open(filename, godot::FileAccess::WRITE);
+
+	if (file.is_valid()) {
+		file->store_string(json_string); // Write JSON text to file
+		file->close();
+	}
+}
+
 void Recorder::save_input_to_json() {
 	if(!json_enabled)
 	{
@@ -513,6 +572,57 @@ void Recorder::load_json_file_to_game() {
 		}
 	}
 
+	if (json_3d_path != NULL) {
+		auto json_data = json_3d_path->get_data(); // JSON file -> Variant
+		godot::Dictionary dict = json_data; // Variant -> Dictionary
+
+		temporary_data_map_2d_pos.clear();
+
+		if (dict.has("frame_count")) {
+			recording_frame = (int)dict["frame_count"];
+		}
+
+		if (dict.has("entries")) {
+			godot::Dictionary entries = dict["entries"];
+
+			godot::Array node_keys = entries.keys();
+			for (int k = 0; k < node_keys.size(); k++) {
+				godot::String node_path_string = node_keys[k];
+				godot::NodePath node_path(node_path_string);
+
+				godot::Node *node = get_node<godot::Node>(node_path);
+
+				godot::Array node_entries = entries[node_path_string];
+				for (int i = 0; i < node_entries.size(); i++) {
+					godot::Dictionary entry = node_entries[i];
+
+					int frame = (int)entry["frame"];
+
+					godot::Variant pos_var = entry["pos"];
+					godot::Vector3 positions;
+
+					if (pos_var.get_type() == godot::Variant::STRING) {
+						godot::String pos_str = pos_var;
+						pos_str = pos_str.strip_edges().replace("(", "").replace(")", ""); // used chat gpt to format the file properly, no idea what this does
+						godot::Array parts = pos_str.split(",");
+
+						if (parts.size() == 3) {
+							positions.x = (float)godot::Variant(parts[0]);
+							positions.y = (float)godot::Variant(parts[1]);
+							positions.z = (float)godot::Variant(parts[2]);
+						} else {
+							godot::print_line("Invalid position string!");
+						}
+					} else {
+						godot::print_line("pos_var is not of type godot::Variant::STRING!");
+					}
+
+					temporary_data_map_3d_pos.insert({ frame, std::make_tuple(node, positions) });
+				}
+			}
+		}
+	}
+
 	if (input_json_path != NULL) {
 		auto json_data = input_json_path->get_data(); // JSON file -> Variant
 
@@ -570,6 +680,16 @@ void Recorder::set_json_path(const godot::Ref<godot::JSON> &p_path)
 		return;
 	}
 	json_path = p_path;
+}
+
+void Recorder::set_3d_json_path(const godot::Ref<godot::JSON> &p_path)
+{
+	if(!json_enabled)
+	{
+		godot::print_error("cant set json path, json saving disabled");
+		return;
+	}
+	json_3d_path = p_path;
 }
 
 void Recorder::set_input_json_path(const godot::Ref<godot::JSON> &p_path) {
@@ -747,6 +867,8 @@ void Recorder::_bind_methods()
 	godot::ClassDB::bind_method(godot::D_METHOD("update"), &Recorder::update);
 	godot::ClassDB::bind_method(godot::D_METHOD("set_tracked_nodes", "new_tracked_nodes"), &Recorder::set_tracked_nodes);
 	godot::ClassDB::bind_method(godot::D_METHOD("set_json_path", "json_file"), &Recorder::set_json_path);
+	godot::ClassDB::bind_method(godot::D_METHOD("set_3d_json_path", "json_file"), &Recorder::set_3d_json_path);
+
 	godot::ClassDB::bind_method(godot::D_METHOD("load_json_file"), &Recorder::load_json_file_to_game);
 	godot::ClassDB::bind_method(godot::D_METHOD("set_input_json_path", "json_file"), &Recorder::set_input_json_path);
 	godot::ClassDB::bind_method(godot::D_METHOD("set_custom_json_path", "json_file"), &Recorder::set_custom_json_path);

--- a/src/recorder.hpp
+++ b/src/recorder.hpp
@@ -65,11 +65,13 @@ protected:
 	void replay_custom_data();
 
 	void save_2dpos_to_json();
+	void save_3dpos_to_json();
 	void save_input_to_json();
 
 	void save_all_to_json()
 	{
 		save_2dpos_to_json();
+		save_3dpos_to_json();
 		save_input_to_json();
 	}
 
@@ -114,6 +116,7 @@ protected:
 	int recording_frame = 0;
 
 	godot::Ref<godot::JSON> json_path;
+	godot::Ref<godot::JSON> json_3d_path;
 	godot::Ref<godot::JSON> input_json_path;
 	godot::Ref<godot::JSON> custom_json_path;
 
@@ -124,6 +127,7 @@ public:
 	godot::Array get_tracked_nodes();
 
 	void set_json_path(const godot::Ref<godot::JSON> &p_path);
+	void set_3d_json_path(const godot::Ref<godot::JSON> &p_path);
 	void set_input_json_path(const godot::Ref<godot::JSON> &p_path);
 	void set_custom_json_path(const godot::Ref<godot::JSON> &p_path);
 


### PR DESCRIPTION
Feature:
Load 3D node position data from JSON and play

Requirements:
Working 3D scene with a valid JSON file containing recorded position, rotation, and scale data.

Acceptance Criteria:

 - [x]  Object accurately move based on the replay data